### PR TITLE
feat(conf): allow to configure Strabon's credentials and configuration properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /.project
+/*.iml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,8 +10,7 @@ services:
   strabon:
     image: bde2020/strabon
     hostname: strabon
+    environment:
+      - STRABON_CONNECTION_hostname=postgis
     ports:
       - "9999:8080"
-    links:
-      - "postgis:postgis"
-

--- a/strabon/Dockerfile
+++ b/strabon/Dockerfile
@@ -8,22 +8,29 @@
 # git 1.9.1                           #
 # tomcat 8.0.23                       #
 #######################################
-
 FROM bde2020/sc7pilotbase:1.0.0
+ARG STRABON_VERSION
+ARG STRABON_TAG="v$STRABON_VERSION"
 
-MAINTAINER Giorgos Argyriou <gioargyr@gmail.com>
+LABEL maintainer='Giorgos Argyriou <gioargyr@gmail.com>'
+LABEL authors='Giorgos Argyriou <gioargyr@gmail.com>, Aurelien Bourdon <aurelien.bourdon@gmail.com>'
 
 RUN apt-get update \
- && apt-get install -y mercurial \
+ && apt-get install --assume-yes mercurial \
+ && apt-get --assume-yes --purge autoremove \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 
 RUN hg clone 'http://hg.strabon.di.uoa.gr/Strabon/' \
- && sed -i 's/localhost/postgis/' /Strabon/endpoint/WebContent/WEB-INF/connection.properties \
  && cd Strabon \
- && mvn clean package
+ && hg up $STRABON_TAG \
+ && mvn package
 
+ENV STRABON_HOME=/tomcat/webapps/strabon
 RUN mkdir /resources \
- && cp /Strabon/endpoint/target/strabon-endpoint-3.3.2-SNAPSHOT.war /tomcat/webapps/strabon.war
+ && unzip -d $STRABON_HOME /Strabon/endpoint/target/strabon-endpoint-$STRABON_VERSION.war
+
+ADD entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 CMD ["/bin/bash", "/runtomcat.sh"]

--- a/strabon/README.md
+++ b/strabon/README.md
@@ -1,0 +1,48 @@
+# Strabon's Docker image
+
+[Strabon](http://www.strabon.di.uoa.gr)'s Docker image.
+
+## How to...
+ 
+### Build it
+
+This Docker image is parameterized by the desired version of Strabon to build, represented by the `STRABON_VERSION` Docker argument.
+
+Example:
+
+```bash
+$ docker build -t bde2020/strabon:3.3.1 --build-arg STRABON_VERSION=3.3.1 .
+```
+
+### Run it
+
+This Docker image allows you to configure the connection and credentials properties used by Strabon, which are typically located in respectively `/WEB-INF/connection.properties` and `/WEB-INF/credentials.properties` Strabon's WAR files.
+To do so, simply define an environment variable named as follow:
+
+```
+STRABON_[CONNECTION | CREDENTIALS]_<property name>
+```
+
+Where:
+- `<property name>` is the name of the property to override in its associated `connection.properties` (`CONNECTION`) or `credentials.properties` (`CREDENTIALS`) file.
+
+Example:
+
+```bash
+$ docker run -e 'STRABON_CONNECTION_hostname=postgis' -e 'STRABON_CONNECTION_port=6789' bde2020/strabon:3.3.1
+```
+
+Or:
+
+```bash
+$ docker run --env-file 'secret-conf.env' bde2020/strabon:3.3.1
+```
+
+Where `secret-conf.env` could be:
+
+```
+STRABON_CONNECTION_hostname=postgis
+STRABON_CONNECTION_port=6789
+STRABON_CREDENTIALS_username=foo
+STRABON_CREDENTIALS_password=bar
+```

--- a/strabon/entrypoint.sh
+++ b/strabon/entrypoint.sh
@@ -1,0 +1,54 @@
+# Exit at any error
+set -e
+
+# Update the given property file by overriding its values based on the environment's ones
+#
+# To override an existing property file's property, environment key has to be named as follow: <PREFIX>_<NAME>, where:
+#   - <PREFIX> is the given environment key's prefix
+#   - <NAME> is the property file's property key name
+#
+# @param $1 path to the property file
+# @param $2 the environment key's prefix
+function updatePropertyFile {
+    local propertyFilePath=$1
+    local environmentPrefix=$2
+
+    local updatedPropertyFile=''
+    # For each property file's property, then
+    while read -r property || [ -n "$property" ]; do
+        if [ -z "$property" ]; then
+            continue
+        fi;
+        # 1. Extract property's key, property's value and potentially associated environment's value
+        local propertyKey=`echo "$property" | grep -o -P '^[^=]+'`
+        local propertyValue=`echo "$property" | grep -o -P '=.*$' | sed 's/^=//'`
+        local overriddenPropertyValue=`printenv "${environmentPrefix}_${propertyKey}"`
+        # 2. Iteratively construct the new property file
+        if [ -n "$updatedPropertyFile" ]; then
+                updatedPropertyFile="$updatedPropertyFile"'\n'
+        fi
+        updatedPropertyFile="${updatedPropertyFile}${propertyKey}=${overriddenPropertyValue:-$propertyValue}"
+    done < $propertyFilePath
+
+    # Finally override the property file by the new constructed one
+    echo -e "$updatedPropertyFile" > $propertyFilePath
+}
+
+# Enhance Strabon's property files
+function enhancePropertyFiles {
+    updatePropertyFile $STRABON_HOME/WEB-INF/credentials.properties STRABON_CREDENTIALS
+    updatePropertyFile $STRABON_HOME/WEB-INF/connection.properties STRABON_CONNECTION
+}
+
+# Run next command (Docker's CMD)
+function runNext {
+    exec "$@"
+}
+
+# Main entry point
+function main {
+    enhancePropertyFiles
+    runNext "$@"
+}
+
+main "$@"


### PR DESCRIPTION
Hi,

Please accept this PR that allows to configure Strabon's credentials and configuration properties.

This PR also:
- Parameterizes Docker build by specifying the version of Strabon to use
- Removes deprecated MAINTAINER Dockerfile keyword
- Removes unnecessary link in docker-compose
- Adds some documentation about how to build/use the Strabon's Docker image

Regards,
Aurélien